### PR TITLE
feat: Add ability to pass route specific configuration to Triage.init.

### DIFF
--- a/lib/triage.js
+++ b/lib/triage.js
@@ -9,6 +9,7 @@
 //  * handler - function to handle the route.
 
 
+const path = require('path');
 const cors = require('cors');
 const globRequire = require('glob-require');
 const joi = require('joi');
@@ -22,21 +23,23 @@ Triage.prototype = {
   init: function (options) {
     options = options || {};
 
-    this.cwd = options.cwd;
-    if (! this.cwd) {
+    this._cwd = options.cwd;
+    if (! this._cwd) {
       throw new Error('missing `cwd` in options');
     }
 
-    this.router = options.router;
-    if (! this.router) {
+    this._router = options.router;
+    if (! this._router) {
       throw new Error('missing `router` in options');
     }
+
+    this._routeConfig = options.route_config || {};
 
     this.load();
   },
 
   load: function () {
-    return loadRoutes(this.cwd).then(this.registerRoutes.bind(this));
+    return loadRoutes(this._cwd, this._routeConfig).then(this.registerRoutes.bind(this));
   },
 
   registerRoutes: function (routes) {
@@ -52,10 +55,10 @@ Triage.prototype = {
       if (typeof route.cors === 'object') options = route.cors;
 
       var corsMiddleware = cors(options);
-      this.router[route.method](route.path, corsMiddleware, handler);
-      this.router.options(route.path, corsMiddleware);
+      this._router[route.method](route.path, corsMiddleware, handler);
+      this._router.options(route.path, corsMiddleware);
     } else {
-      this.router[route.method](route.path, handler);
+      this._router[route.method](route.path, handler);
     }
   }
 };
@@ -77,7 +80,7 @@ function validateRoute(route) {
 
 module.exports = Triage;
 
-function loadRoutes(root) {
+function loadRoutes(root, routeConfig) {
   return new Promises(function (fulfill, reject) {
     globRequire(root, function (err, modules) {
       if (err) return reject(err);
@@ -86,7 +89,8 @@ function loadRoutes(root) {
         var route = module.exports;
 
         if (typeof route === 'function') {
-          route = new route();
+          var basename = path.basename(module.path, '.js');
+          route = new route(routeConfig[basename]);
         }
 
         route.filename = module.path;

--- a/test/mocks/routes/GET-require-initialization.js
+++ b/test/mocks/routes/GET-require-initialization.js
@@ -4,7 +4,7 @@
 
 // A route that needs to be initialized by running the function.
 
-module.exports = function () {
+module.exports = function (config) {
   return {
     path: '/requires_initialization',
     method: 'get',
@@ -14,8 +14,10 @@ module.exports = function () {
       return true;
     },
 
-    handler: function() {
-      return {};
+    handler: function () {
+      return {
+        key: config.key
+      };
     },
   };
 };

--- a/test/spec/triage_test.js
+++ b/test/spec/triage_test.js
@@ -36,6 +36,11 @@ describe('a route handler', function () {
     triage.init({
       cwd: TEST_ROUTES_DIRECTORY,
       router: router,
+      route_config: {
+        'GET-require-initialization': {
+          key: 'value'
+        }
+      }
     });
   });
 
@@ -165,7 +170,8 @@ describe('a route handler', function () {
       request.url = '/requires_initialization';
 
       router.handle(request, {
-        render: function () {
+        render: function (template, templateData) {
+          assert.equal(templateData.key, 'value');
           done();
         }
       });


### PR DESCRIPTION
In triage.init, pass a `route_config` hash can be passed with route specific configuration.

```js
var triage = new Triage();
triage.init({
  cwd: <dir>,
  router: router,
  route_config: {
    <ROUTE_DEFINITION_FILENAME>: <config>
  }
});
```